### PR TITLE
Update plugins.md documentation for PLUGINS_DIR

### DIFF
--- a/docs/docs/setup/plugins.md
+++ b/docs/docs/setup/plugins.md
@@ -99,7 +99,7 @@ RUN cd /custom_plugins/myplugin1/frontend && npm install && npm run generate
 FROM syslifters/sysreptor:${SYSREPTOR_VERSION}
 # Optional: install additional dependencies
 # RUN pip install ...
-ENV PLUGIN_DIRS=${PLUGIN_DIRS}:/custom_plugins
+ENV PLUGIN_DIRS=${PLUGIN_DIRS},/custom_plugins
 COPY --from=plugin-builder /custom_plugins /custom_plugins
 ```
 


### PR DESCRIPTION
The `PLUGINS_DIR` setting is currently read in [settings.py:585](api/src/sysreptor/conf/settings.py:585)

```py
PLUGIN_DIRS = config('PLUGIN_DIRS', cast=Csv(cast=Path, post_process=remove_empty_items), default='')
```

This splits the environment value by `,` (which is the default separator with `Csv`) and not `:` as implied by the documentation. This merge request updates the documentation to follow the code, alternatively, the following update to the `settings.py` file would work to update the code to follow the documentation:

```py
PLUGIN_DIRS = config('PLUGIN_DIRS', cast=Csv(delimiter=':', cast=Path, post_process=remove_empty_items), default='')
```