### PR TITLE
Fix space after figure references

### DIFF
--- a/api/src/sysreptor/pentests/rendering/global_assets/base-ref.css
+++ b/api/src/sysreptor/pentests/rendering/global_assets/base-ref.css
@@ -189,7 +189,7 @@ figcaption::before {
   content: var(--prefix-figure) counter(figure-counter) " - ";
 }
 .ref-figure::before {
-  content: var(--prefix-figure) target-counter(attr(href), figure-counter);
+  content: var(--prefix-figure) target-counter(attr(href), figure-counter) " ";
 }
 .ref-figure > .ref-title {
   display: none;


### PR DESCRIPTION
When referencing figures, the figure ref title is intentionally hidden. However, due to the ref title being hidden, there is no implicit space added to the `::before` pseudo-element under certain circumstances:

```html
<ref to="fig1" />abc
<figure id="fig1">...</figure>
<ref to="fig1" />def
```
Here, the first reference would render as `Figure 1abc`, whereas the second reference renders as `Figure 1 abc`.
This PR simply forces the space to be present for figure references, resolving this inconsistency. (Note that due to an explicit space being present, there isn't any implicit space being added during rendering -> there aren't any double spaces introduced with this fix)