### PR TITLE
Add italian translation for figure and table prefix

### DIFF
--- a/api/src/sysreptor/pentests/rendering/global_assets/base-ref.css
+++ b/api/src/sysreptor/pentests/rendering/global_assets/base-ref.css
@@ -20,6 +20,10 @@
   --prefix-figure: "Figura ";
   --prefix-table: "Tabela ";
 }
+:root:lang(it) {
+  --prefix-figure: "Figura ";
+  --prefix-table: "Tabella ";
+}
 
 
 /* Define counters */


### PR DESCRIPTION
SysReptor is missing the italian translation for figure and table prefix in the `base-ref.css` asset, which causes a fallback to english language. I simply added the translation like other supported languages:
```
:root:lang(it) {
  --prefix-figure: "Figura ";
  --prefix-table: "Tabella ";
}
```