### PR TITLE
Shortcuts Documentation Page

### DIFF
--- a/docs/docs/reporting/shortcuts.md
+++ b/docs/docs/reporting/shortcuts.md
@@ -1,0 +1,25 @@
+# Shortcuts
+
+Below is a list of shortcuts that SysReptor currently supports. 
+
+**UI Shortcuts**
+
+- `CTRL + Z` - Undo
+- `CTRL + SHIFT + Z` / `CTRL Y` - Redo
+- `CTRL + S` - Save design/template
+- `CTRL + SHIFT + F` - Search in all notes/findings/sections
+- `CTRL + J` - Create a new note/finding
+- `CTRL + ALT + M` - Create comment
+
+**Markdown Shortcuts**
+
+- `CTRL + B` - Bold
+- `CTRL + I` - Italic
+- `ALT + LEFT MOUSE` - Multi-line select
+- `SHIFT + ALT + UP/DOWN ARROW` - Duplicate line
+- `ALT + UP/DOWN ARROW` - Move line up/down
+- `ALT + LEFT/RIGHT ARROW` - Jump to the next markdown element
+- `ALT + I` - Select line
+- `CTRL + SHIFT + K` - Delete line
+- `SHIFT + ALT + A` - Add/remove HTML content
+- `CTRL + F` - Search for text


### PR DESCRIPTION
This PR adds a new page to the SysReptor documentation page to document the keybindings and descriptions for all of the shortcuts that SysReptor currently supports. This PR addresses issue #486. 

Source for shortcuts: https://github.com/Syslifters/sysreptor/discussions/399

I'm happy to discuss any proposed edits or changes :)

Thanks for making SysReptor such an awesome tool! 