### PR TITLE
Add Prowler and ScoutSuite importers to scanimport plugin

### DIFF
--- a/plugins/scanimport/README.md
+++ b/plugins/scanimport/README.md
@@ -27,7 +27,9 @@ The plugin currently supports the following security testing tools:
 | **Nessus** | .nessus (XML) | Findings/Notes | Vulnerability scanner |
 | **Nmap** | XML/Greppable | Findings/Notes | Network discovery and security auditing |
 | **OpenVAS** | XML | Findings/Notes | Vulnerability assessment system |
+| **Prowler** | CSV/JSON (OCSF) | Findings/Notes | AWS/cloud security assessment tool |
 | **Qualys** | XML | Findings/Notes | Cloud security and compliance platform |
+| **ScoutSuite** | JS/JSON | Findings/Notes | Multi-cloud security auditing tool |
 | **SSLyze** | JSON | Findings/Notes | SSL/TLS configuration scanner |
 | **OWASP ZAP** | XML/JSON | Findings/Notes | Web application security scanner |
 

--- a/plugins/scanimport/apps.py
+++ b/plugins/scanimport/apps.py
@@ -4,7 +4,7 @@ from sysreptor.plugins import PluginConfig
 class ScanImportPluginConfig(PluginConfig):
     """
     Import scan results from various tools.
-    Supported tools: Burp, Nessus, Nmap, OpenVAS, Qualys, SSLyze, ZAP
+    Supported tools: Burp, Nessus, Nmap, OpenVAS, Prowler, Qualys, ScoutSuite, SSLyze, ZAP
     """
 
     plugin_id = '2335e86b-198c-4e6c-9563-8190a05ee38c'

--- a/plugins/scanimport/importers/__init__.py
+++ b/plugins/scanimport/importers/__init__.py
@@ -3,7 +3,9 @@ from .burp import BurpImporter
 from .nessus import NessusImporter
 from .nmap import NmapImporter
 from .openvas import OpenVASImporter
+from .prowler import ProwlerImporter
 from .qualys import QualysImporter
+from .scoutsuite import ScoutSuiteImporter
 from .sslyze import SslyzeImporter
 from .zap import ZapImporter
 
@@ -11,13 +13,16 @@ registry.register(BurpImporter())
 registry.register(NessusImporter())
 registry.register(NmapImporter())
 registry.register(OpenVASImporter())
+registry.register(ProwlerImporter())
 registry.register(QualysImporter())
+registry.register(ScoutSuiteImporter())
 registry.register(SslyzeImporter())
 registry.register(ZapImporter())
 
 
 __all__ = [
     'BaseImporter', 'registry',
-    'BurpImporter', 'NessusImporter', 'NmapImporter', 'OpenVASImporter', 
-    'QualysImporter', 'SslyzeImporter', 'ZapImporter',
+    'BurpImporter', 'NessusImporter', 'NmapImporter', 'OpenVASImporter',
+    'ProwlerImporter', 'QualysImporter', 'ScoutSuiteImporter', 'SslyzeImporter',
+    'ZapImporter',
 ]

--- a/plugins/scanimport/importers/prowler.py
+++ b/plugins/scanimport/importers/prowler.py
@@ -1,0 +1,301 @@
+import csv
+import io
+import json
+import textwrap
+
+from sysreptor.pentests.models import (
+    FindingTemplateTranslation,
+    Language,
+    ProjectNotebookPage,
+)
+from sysreptor.utils.utils import groupby_to_dict
+
+from ..utils import render_template_string
+from .base import BaseImporter, fallback_template
+
+# Prowler's own severity scale maps almost 1:1 onto SysReptor's, aside from
+# spelling out "informational" in full.
+SEVERITY_MAPPING = {
+    "critical": "critical",
+    "high": "high",
+    "medium": "medium",
+    "low": "low",
+    "informational": "info",
+    "info": "info",
+}
+
+# OCSF severity_id -> SysReptor severity, used as a fallback when the textual
+# `severity` field is absent. (OCSF: 1=Informational .. 5=Critical, 6=Fatal.)
+OCSF_SEVERITY_ID_MAPPING = {1: "info", 2: "low", 3: "medium", 4: "high", 5: "critical", 6: "critical"}
+
+# Column names have varied a little across Prowler v3/v4 CSV exports -
+# list the aliases we know about so this keeps working across versions.
+COLUMN_ALIASES = {
+    "check_id": ["CHECK_ID", "CheckID", "check_id"],
+    "title": ["CHECK_TITLE", "Title", "check_title"],
+    "severity": ["SEVERITY", "Severity", "severity"],
+    "status": ["STATUS", "Status", "status"],
+    "status_extended": ["STATUS_EXTENDED", "StatusExtended", "status_extended"],
+    "service": ["SERVICE_NAME", "ServiceName", "service_name"],
+    "resource": ["RESOURCE_UID", "RESOURCE_TYPE", "ResourceId", "resource_uid"],
+    "region": ["REGION", "Region", "region"],
+    "account": ["ACCOUNT_ID", "AccountId", "account_id"],
+}
+
+REQUIRED_FOR_DETECTION = {"check_id", "status"}
+
+
+def _resolve_columns(fieldnames):
+    fieldnames = fieldnames or []
+    return {key: next((a for a in aliases if a in fieldnames), None) for key, aliases in COLUMN_ALIASES.items()}
+
+
+def _sniff_dialect(sample):
+    try:
+        return csv.Sniffer().sniff(sample, delimiters=";,")
+    except csv.Error:
+        return csv.excel
+
+
+class ProwlerImporter(BaseImporter):
+    id = 'prowler'
+
+    fallback_templates = [fallback_template(tags=[f'scanimport:{id}'], translations=[
+        FindingTemplateTranslation(
+            language=Language.ENGLISH_US,
+            custom_fields={
+                'summary': '<!--{{ status_extended|default:title }}-->',
+                'description': textwrap.dedent("""\
+                    <!--{{ status_extended }}-->
+
+                    Affected resources (<!--{{ affected_components|length }}-->):
+                    <!--{% for c in affected_components %}-->
+                    - <!--{{ c }}-->
+                    <!--{% endfor %}-->
+                    """),
+            },
+        ),
+    ])]
+
+    # ---- format handling -------------------------------------------------
+    # Prowler v5 emits both CSV and JSON-OCSF by default; we accept either.
+    # Both are normalised to the same finding dict shape so the merge, notes
+    # and findings pipeline below is format-agnostic.
+
+    def _read_text(self, file):
+        file.seek(0)
+        return file.read().decode('utf-8', errors='replace')
+
+    @staticmethod
+    def _looks_like_json(text):
+        return text.lstrip()[:1] in ('[', '{')
+
+    def is_format(self, file):
+        try:
+            text = self._read_text(file)
+        except Exception:
+            return False
+        return self._is_ocsf(text) if self._looks_like_json(text) else self._is_csv(text)
+
+    # ---- CSV -------------------------------------------------------------
+
+    def _read_rows(self, text):
+        dialect = _sniff_dialect(text[:4096])
+        reader = csv.DictReader(io.StringIO(text), dialect=dialect)
+        return reader.fieldnames or [], list(reader)
+
+    def _is_csv(self, text):
+        try:
+            fieldnames, _ = self._read_rows(text)
+        except Exception:
+            return False
+        col = _resolve_columns(fieldnames)
+        return all(col[key] for key in REQUIRED_FOR_DETECTION)
+
+    def _parse_csv(self, text):
+        fieldnames, rows = self._read_rows(text)
+        col = _resolve_columns(fieldnames)
+        if not col["check_id"]:
+            return []
+
+        findings = []
+        for row in rows:
+            status = (row.get(col["status"], "") or "").strip().upper() if col["status"] else "FAIL"
+            if status != "FAIL":
+                # Drop PASS/MANUAL/NOT_APPLICABLE rows - this is the "minimise
+                # the noise" step: Prowler emits one row per check per
+                # resource, and only FAILs are actual findings.
+                continue
+
+            severity_raw = (row.get(col["severity"], "") or "info").strip().lower() if col["severity"] else "info"
+            resource = (row.get(col["resource"], "") or "").strip() if col["resource"] else ""
+
+            findings.append({
+                "check_id": (row.get(col["check_id"], "") or "").strip(),
+                "title": (row.get(col["title"], "") or "").strip() if col["title"] else "",
+                "severity": SEVERITY_MAPPING.get(severity_raw, "info"),
+                "status_extended": (row.get(col["status_extended"], "") or "").strip() if col["status_extended"] else "",
+                "service": (row.get(col["service"], "") or "").strip() if col["service"] else "",
+                "region": (row.get(col["region"], "") or "").strip() if col["region"] else "",
+                "account": (row.get(col["account"], "") or "").strip() if col["account"] else "",
+                "affected_components": [resource] if resource else [],
+                "references": [],
+            })
+        return findings
+
+    # ---- JSON-OCSF -------------------------------------------------------
+
+    @staticmethod
+    def _load_ocsf(text):
+        data = json.loads(text)
+        # Prowler emits a JSON array of OCSF detection findings; tolerate a
+        # single object too.
+        return [data] if isinstance(data, dict) else data
+
+    def _is_ocsf(self, text):
+        try:
+            data = self._load_ocsf(text)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return False
+        if not isinstance(data, list):
+            return False
+        first = next((f for f in data if isinstance(f, dict)), None)
+        if not first:
+            return False
+        # The Prowler check id lives in metadata.event_code (with unmapped.check_id
+        # as an older fallback); paired with a status field this is enough to
+        # distinguish Prowler OCSF from other JSON reports (ScoutSuite, SSLyze, ZAP).
+        metadata = first.get('metadata') or {}
+        unmapped = first.get('unmapped') or {}
+        has_check = bool(metadata.get('event_code') or unmapped.get('check_id'))
+        has_status = ('status_code' in first) or ('status' in first)
+        return has_check and has_status
+
+    def _parse_ocsf(self, text):
+        try:
+            data = self._load_ocsf(text)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return []
+
+        findings = []
+        for fo in data:
+            if not isinstance(fo, dict):
+                continue
+            status = str(fo.get('status_code') or fo.get('status') or 'FAIL').strip().upper()
+            if status != 'FAIL':
+                continue
+
+            metadata = fo.get('metadata') or {}
+            unmapped = fo.get('unmapped') or {}
+            finding_info = fo.get('finding_info') or {}
+            cloud = fo.get('cloud') or {}
+            remediation = fo.get('remediation') or {}
+
+            check_id = (metadata.get('event_code') or unmapped.get('check_id') or '').strip()
+
+            severity = fo.get('severity')
+            if severity:
+                severity = SEVERITY_MAPPING.get(str(severity).strip().lower(), 'info')
+            else:
+                severity = OCSF_SEVERITY_ID_MAPPING.get(fo.get('severity_id'), 'info')
+
+            components, service, region = [], '', ''
+            for r in (fo.get('resources') or []):
+                if not isinstance(r, dict):
+                    continue
+                uid = (r.get('uid') or r.get('name') or '').strip()
+                if uid:
+                    components.append(uid)
+                if not service:
+                    group = r.get('group') or {}
+                    service = (group.get('name') if isinstance(group, dict) else '') or ''
+                if not region:
+                    region = (r.get('region') or '').strip()
+            service = service or (unmapped.get('service_name') or '').strip()
+            region = region or (cloud.get('region') or '').strip()
+
+            account = cloud.get('account') or {}
+            account = (account.get('uid') if isinstance(account, dict) else '') or (fo.get('account_uid') or '')
+
+            references = remediation.get('references') or []
+            if not isinstance(references, list):
+                references = []
+
+            findings.append({
+                "check_id": check_id,
+                "title": (finding_info.get('title') or check_id).strip(),
+                "severity": severity,
+                "status_extended": (fo.get('status_detail') or '').strip(),
+                "service": service,
+                "region": region,
+                "account": account.strip(),
+                "affected_components": list(dict.fromkeys(components)),
+                "references": list(references),
+            })
+        return findings
+
+    # ---- shared pipeline -------------------------------------------------
+
+    def parse_prowler_findings(self, files):
+        findings = []
+        for file in files:
+            text = self._read_text(file)
+            findings.extend(self._parse_ocsf(text) if self._looks_like_json(text) else self._parse_csv(text))
+        return findings
+
+    def merge_findings_by_check(self, findings):
+        """One finding per CHECK_ID, with every failing resource listed as an
+        affected component - mirrors how the Nessus importer merges by
+        plugin ID, and is what turns "50 rows, one per resource" into a
+        single, sensible finding. Title, severity and references of a specific
+        check can be customised via a scanimport:prowler:<check_id> finding
+        template, the same way the other importers are customised."""
+        out = []
+        for _, group in groupby_to_dict(findings, key=lambda f: f['check_id']).items():
+            merged = dict(group[0])
+            merged['affected_components'] = list(merged['affected_components'])
+            merged['references'] = list(merged.get('references') or [])
+            for f in group[1:]:
+                merged['affected_components'] = list(dict.fromkeys(merged['affected_components'] + f['affected_components']))
+                merged['references'] = list(dict.fromkeys(merged['references'] + (f.get('references') or [])))
+            out.append(merged)
+        return out
+
+    def parse_notes(self, files):
+        notes = []
+        note_root = ProjectNotebookPage(title='Prowler', icon_emoji='☁️')
+        notes.append(note_root)
+
+        findings = self.merge_findings_by_check(self.parse_prowler_findings(files))
+        order = 0
+        for service, service_findings in groupby_to_dict(findings, key=lambda f: f['service'] or 'other').items():
+            order += 1
+            notes.append(ProjectNotebookPage(
+                parent=note_root,
+                order=order,
+                checked=False,
+                title=service,
+                text=render_template_string(textwrap.dedent("""\
+                    | Check | Severity | Resources |
+                    | ------- | -------- | --------- |
+                    <!--{% for f in findings %}-->| <!--{{ f.title }}--> | <!--{{ f.severity }}--> | <!--{{ f.affected_components|length }}--> |
+                    <!--{% endfor %}-->
+                    """), context={'findings': service_findings}),
+            ))
+        return notes
+
+    def parse_findings(self, files, project):
+        findings = []
+        templates = self.get_all_finding_templates()
+        for issue in self.merge_findings_by_check(self.parse_prowler_findings(files)):
+            findings.append(self.generate_finding_from_template(
+                project=project,
+                tr=self.select_finding_template(
+                    templates=templates,
+                    fallback=self.fallback_templates,
+                    selector=issue.get('check_id'),
+                    language=project.language,
+                ),
+                data=issue,
+            ))
+        return findings

--- a/plugins/scanimport/importers/scoutsuite.py
+++ b/plugins/scanimport/importers/scoutsuite.py
@@ -1,0 +1,167 @@
+import json
+import re
+import textwrap
+
+from sysreptor.pentests.models import (
+    FindingTemplateTranslation,
+    Language,
+    ProjectNotebookPage,
+)
+from sysreptor.utils.utils import groupby_to_dict
+
+from ..utils import render_template_string
+from .base import BaseImporter, fallback_template
+
+# ScoutSuite finding "level" -> SysReptor's 5-point severity scale.
+# ScoutSuite has no notion of "critical" itself, so "danger" is mapped to
+# "high" by default - bump specific checks up via a scanimport:scoutsuite:<finding_id>
+# finding template if a particular check should always be critical for you.
+LEVEL_TO_SEVERITY = {
+    "danger": "high",
+    "warning": "medium",
+    "good_practice": "info",
+    "info": "info",
+}
+
+
+class ScoutSuiteImporter(BaseImporter):
+    id = 'scoutsuite'
+
+    fallback_templates = [fallback_template(tags=[f'scanimport:{id}'], translations=[
+        FindingTemplateTranslation(
+            language=Language.ENGLISH_US,
+            custom_fields={
+                'summary': '<!--{{ rationale|default:description }}-->',
+                'description': textwrap.dedent("""\
+                    <!--{{ description }}-->
+
+                    Affected resources (<!--{{ affected_components|length }}-->):
+                    <!--{% for c in affected_components %}-->
+                    - <!--{{ c }}-->
+                    <!--{% endfor %}-->
+                    """),
+            },
+        ),
+    ])]
+
+    def is_format(self, file):
+        try:
+            self._load_scoutsuite_json(file)
+            return True
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return False
+
+    def _load_scoutsuite_json(self, file):
+        file.seek(0)
+        raw = file.read().decode('utf-8', errors='strict').strip()
+
+        # ScoutSuite's default report is a .js file containing a single
+        # assignment: `scoutsuite_results = { ... };`. Strip that wrapper if
+        # present so both the .js report and a plain .json export work.
+        m = re.search(r"=\s*(\{.*\})\s*;?\s*$", raw, re.DOTALL)
+        json_text = m.group(1) if m else raw
+
+        data = json.loads(json_text)
+        if not isinstance(data, dict) or 'services' not in data:
+            raise json.JSONDecodeError("Not a ScoutSuite report (missing 'services' key)", json_text, 0)
+        return data
+
+    def parse_scoutsuite_findings(self, files):
+        findings = []
+        for file in files:
+            results = self._load_scoutsuite_json(file)
+            account = (
+                results.get('account_id')
+                or results.get('aws_account_id')
+                or results.get('provider_name')
+                or 'unknown'
+            )
+            services = results.get('services', {})
+            for service_name, service_data in services.items():
+                if not isinstance(service_data, dict):
+                    continue
+                for finding_id, finding in (service_data.get('findings') or {}).items():
+                    if not isinstance(finding, dict):
+                        continue
+
+                    level = (finding.get('level') or 'warning').lower()
+                    severity = LEVEL_TO_SEVERITY.get(level, 'medium')
+
+                    items = finding.get('items') or []
+                    if not isinstance(items, list):
+                        items = [str(items)]
+
+                    region = None
+                    if items and isinstance(items[0], str):
+                        parts = items[0].split('.')
+                        if len(parts) > 1 and parts[0] == 'regions':
+                            region = parts[1]
+
+                    findings.append({
+                        'finding_id': finding_id,
+                        'title': (finding.get('description') or finding_id).strip(),
+                        'severity': severity,
+                        'service': service_name,
+                        'region': region,
+                        'account': account,
+                        'description': (finding.get('description') or '').strip(),
+                        'rationale': (finding.get('rationale') or '').strip(),
+                        'references': list(finding.get('references') or []),
+                        'affected_components': list(items),
+                    })
+        return findings
+
+    def merge_findings_by_check(self, findings):
+        """One finding per (service, finding_id) - matches how the Nessus
+        importer merges by plugin ID, so the same check across many
+        resources/accounts becomes a single finding rather than dozens of
+        near-duplicates. Title, severity and references of a specific check
+        can be customised via a scanimport:scoutsuite:<finding_id> finding
+        template, the same way the other importers are customised."""
+        out = []
+        for _, group in groupby_to_dict(findings, key=lambda f: (f['service'], f['finding_id'])).items():
+            merged = group[0]
+            for f in group[1:]:
+                merged['affected_components'] = list(dict.fromkeys(merged['affected_components'] + f['affected_components']))
+                merged['references'] = list(dict.fromkeys(merged['references'] + f['references']))
+            out.append(merged)
+        return out
+
+    def parse_notes(self, files):
+        notes = []
+        note_root = ProjectNotebookPage(title='ScoutSuite', icon_emoji='🔎')
+        notes.append(note_root)
+
+        findings = self.merge_findings_by_check(self.parse_scoutsuite_findings(files))
+        order = 0
+        for service, service_findings in groupby_to_dict(findings, key=lambda f: f['service']).items():
+            order += 1
+            notes.append(ProjectNotebookPage(
+                parent=note_root,
+                order=order,
+                checked=False,
+                title=service,
+                text=render_template_string(textwrap.dedent("""\
+                    | Finding | Severity | Resources |
+                    | ------- | -------- | --------- |
+                    <!--{% for f in findings %}-->| <!--{{ f.title }}--> | <!--{{ f.severity }}--> | <!--{{ f.affected_components|length }}--> |
+                    <!--{% endfor %}-->
+                    """), context={'findings': service_findings}),
+            ))
+        return notes
+
+    def parse_findings(self, files, project):
+        findings = []
+        templates = self.get_all_finding_templates()
+        for issue in self.merge_findings_by_check(self.parse_scoutsuite_findings(files)):
+            findings.append(self.generate_finding_from_template(
+                project=project,
+                tr=self.select_finding_template(
+                    templates=templates,
+                    fallback=self.fallback_templates,
+                    selector=issue.get('finding_id'),
+                    language=project.language,
+                ),
+                data=issue,
+            ))
+        return findings

--- a/plugins/scanimport/tests/data/prowler/prowler_ocsf.json
+++ b/plugins/scanimport/tests/data/prowler/prowler_ocsf.json
@@ -1,0 +1,70 @@
+[
+  {
+    "metadata": {"event_code": "s3_bucket_public_access", "product": {"name": "Prowler"}},
+    "severity": "High",
+    "severity_id": 4,
+    "status_code": "FAIL",
+    "status": "New",
+    "status_detail": "Bucket bucket-one is publicly accessible",
+    "finding_info": {"uid": "prowler-aws-s3_bucket_public_access-1", "title": "S3 Bucket has public access configured"},
+    "resources": [
+      {"uid": "arn:aws:s3:::bucket-one", "name": "bucket-one", "type": "AwsS3Bucket", "region": "eu-west-1", "group": {"name": "s3"}}
+    ],
+    "cloud": {"account": {"uid": "123456789012"}, "region": "eu-west-1", "provider": "aws"},
+    "remediation": {"desc": "Block public access on the bucket.", "references": ["https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html"]}
+  },
+  {
+    "metadata": {"event_code": "s3_bucket_public_access", "product": {"name": "Prowler"}},
+    "severity": "High",
+    "severity_id": 4,
+    "status_code": "FAIL",
+    "status": "New",
+    "status_detail": "Bucket bucket-two is publicly accessible",
+    "finding_info": {"uid": "prowler-aws-s3_bucket_public_access-2", "title": "S3 Bucket has public access configured"},
+    "resources": [
+      {"uid": "arn:aws:s3:::bucket-two", "name": "bucket-two", "type": "AwsS3Bucket", "region": "eu-west-1", "group": {"name": "s3"}}
+    ],
+    "cloud": {"account": {"uid": "123456789012"}, "region": "eu-west-1", "provider": "aws"},
+    "remediation": {"desc": "Block public access on the bucket.", "references": []}
+  },
+  {
+    "metadata": {"event_code": "iam_password_policy_minimum_length_14", "product": {"name": "Prowler"}},
+    "severity": "Medium",
+    "severity_id": 3,
+    "status_code": "FAIL",
+    "status": "New",
+    "status_detail": "Password policy requires minimum length of 8",
+    "finding_info": {"uid": "prowler-aws-iam_password_policy_minimum_length_14-1", "title": "Ensure IAM password policy requires minimum length of 14"},
+    "resources": [
+      {"uid": "arn:aws:iam::123456789012:account", "name": "account", "type": "AwsIamAccount", "region": "us-east-1", "group": {"name": "iam"}}
+    ],
+    "cloud": {"account": {"uid": "123456789012"}, "region": "us-east-1", "provider": "aws"},
+    "remediation": {"desc": "Set the minimum password length to 14.", "references": []}
+  },
+  {
+    "metadata": {"event_code": "ec2_ebs_volume_encryption", "product": {"name": "Prowler"}},
+    "severity": "Low",
+    "severity_id": 2,
+    "status_code": "PASS",
+    "status": "New",
+    "status_detail": "Volume vol-abc is encrypted",
+    "finding_info": {"uid": "prowler-aws-ec2_ebs_volume_encryption-1", "title": "Ensure EBS volumes are encrypted"},
+    "resources": [
+      {"uid": "vol-abc", "name": "vol-abc", "type": "AwsEc2Volume", "region": "eu-west-1", "group": {"name": "ec2"}}
+    ],
+    "cloud": {"account": {"uid": "123456789012"}, "region": "eu-west-1", "provider": "aws"}
+  },
+  {
+    "metadata": {"event_code": "guardduty_is_enabled", "product": {"name": "Prowler"}},
+    "severity": "Medium",
+    "severity_id": 3,
+    "status_code": "MANUAL",
+    "status": "New",
+    "status_detail": "Requires manual verification",
+    "finding_info": {"uid": "prowler-aws-guardduty_is_enabled-1", "title": "Ensure GuardDuty is enabled"},
+    "resources": [
+      {"uid": "n/a", "name": "n/a", "type": "AwsGuardDutyDetector", "region": "eu-west-1", "group": {"name": "guardduty"}}
+    ],
+    "cloud": {"account": {"uid": "123456789012"}, "region": "eu-west-1", "provider": "aws"}
+  }
+]

--- a/plugins/scanimport/tests/data/prowler/prowler_v3.csv
+++ b/plugins/scanimport/tests/data/prowler/prowler_v3.csv
@@ -1,0 +1,4 @@
+check_id;check_title;severity;status;status_extended;service_name;resource_uid;region;account_id
+rds_instance_backup_enabled;RDS instance has backups enabled;low;FAIL;Automated backups disabled for db-1;rds;arn:aws:rds:eu-west-1:123456789012:db:db-1;eu-west-1;123456789012
+cloudtrail_multi_region_enabled;Ensure CloudTrail is enabled in all regions;medium;FAIL;Multi-region trail not configured;cloudtrail;arn:aws:cloudtrail:us-east-1:123456789012:trail/main;us-east-1;123456789012
+ec2_instance_managed_by_ssm;Ensure EC2 instances are managed by SSM;low;PASS;Instance i-123 managed by SSM;ec2;i-123;eu-west-1;123456789012

--- a/plugins/scanimport/tests/data/prowler/prowler_v4.csv
+++ b/plugins/scanimport/tests/data/prowler/prowler_v4.csv
@@ -1,0 +1,6 @@
+CHECK_ID,CHECK_TITLE,SEVERITY,STATUS,STATUS_EXTENDED,SERVICE_NAME,RESOURCE_UID,REGION,ACCOUNT_ID
+s3_bucket_public_access,S3 Bucket has public access configured,high,FAIL,Bucket bucket-one is publicly accessible,s3,arn:aws:s3:::bucket-one,eu-west-1,123456789012
+s3_bucket_public_access,S3 Bucket has public access configured,high,FAIL,Bucket bucket-two is publicly accessible,s3,arn:aws:s3:::bucket-two,eu-west-1,123456789012
+iam_password_policy_minimum_length_14,Ensure IAM password policy requires minimum length of 14,medium,FAIL,Password policy requires minimum length of 8,iam,arn:aws:iam::123456789012:account,us-east-1,123456789012
+ec2_ebs_volume_encryption,Ensure EBS volumes are encrypted,low,PASS,Volume vol-abc is encrypted,ec2,vol-abc,eu-west-1,123456789012
+guardduty_is_enabled,Ensure GuardDuty is enabled,medium,MANUAL,Requires manual verification,guardduty,n/a,eu-west-1,123456789012

--- a/plugins/scanimport/tests/data/scoutsuite/scoutsuite_results.js
+++ b/plugins/scanimport/tests/data/scoutsuite/scoutsuite_results.js
@@ -1,0 +1,39 @@
+scoutsuite_results =
+{
+    "account_id": "123456789012",
+    "provider_name": "Amazon Web Services",
+    "services": {
+        "s3": {
+            "findings": {
+                "s3-bucket-allowing-cleartext": {
+                    "level": "danger",
+                    "description": "S3 bucket allows cleartext (HTTP) requests",
+                    "rationale": "Data in transit should be encrypted using HTTPS.",
+                    "references": ["https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html"],
+                    "items": [
+                        "regions.eu-west-1.buckets.bucket-one",
+                        "regions.eu-west-1.buckets.bucket-two"
+                    ]
+                },
+                "s3-bucket-versioning-disabled": {
+                    "level": "warning",
+                    "description": "S3 bucket versioning is disabled",
+                    "rationale": "Versioning protects against accidental deletion and overwrites.",
+                    "references": [],
+                    "items": ["regions.eu-west-1.buckets.bucket-three"]
+                }
+            }
+        },
+        "iam": {
+            "findings": {
+                "iam-password-policy-expiration": {
+                    "level": "good_practice",
+                    "description": "Password expiration policy is configured",
+                    "rationale": "",
+                    "references": [],
+                    "items": ["regions.global.password_policy"]
+                }
+            }
+        }
+    }
+};

--- a/plugins/scanimport/tests/data/scoutsuite/scoutsuite_results.json
+++ b/plugins/scanimport/tests/data/scoutsuite/scoutsuite_results.json
@@ -1,0 +1,17 @@
+{
+    "account_id": "210987654321",
+    "provider_name": "Amazon Web Services",
+    "services": {
+        "ec2": {
+            "findings": {
+                "ec2-security-group-opens-all-ports-to-all": {
+                    "level": "danger",
+                    "description": "Security group opens all ports to 0.0.0.0/0",
+                    "rationale": "Security groups should restrict access to required ports only.",
+                    "references": [],
+                    "items": ["regions.eu-west-1.vpcs.vpc-1.security_groups.sg-123.rules.ingress"]
+                }
+            }
+        }
+    }
+}

--- a/plugins/scanimport/tests/test_prowler.py
+++ b/plugins/scanimport/tests/test_prowler.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from sysreptor.tests.mock import create_project, create_user
+
+from ..importers import registry
+
+PROWLER_DATA_DIR = Path(__file__).parent / "data" / "prowler"
+PROWLER_V4_PATH = PROWLER_DATA_DIR / "prowler_v4.csv"
+PROWLER_V3_PATH = PROWLER_DATA_DIR / "prowler_v3.csv"
+PROWLER_OCSF_PATH = PROWLER_DATA_DIR / "prowler_ocsf.json"
+
+
+@pytest.mark.django_db
+class TestProwlerImporter:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.project = create_project(members=[create_user()])
+        self.importer = registry.get('prowler')
+
+    def test_is_format_comma_delimited(self):
+        with PROWLER_V4_PATH.open('rb') as f:
+            assert self.importer.is_format(f) is True
+
+    def test_is_format_semicolon_delimited(self):
+        with PROWLER_V3_PATH.open('rb') as f:
+            assert self.importer.is_format(f) is True
+
+    def test_is_format_rejects_non_prowler_csv(self):
+        # A CSV without the required CHECK_ID/STATUS columns is not Prowler output.
+        f = SimpleUploadedFile("other.csv", b"name,value\nfoo,bar\n")
+        assert self.importer.is_format(f) is False
+
+    def test_is_format_rejects_non_csv(self):
+        f = SimpleUploadedFile("data.txt", b"just some plain text without columns")
+        assert self.importer.is_format(f) is False
+
+    def test_only_failed_checks_are_kept(self):
+        # prowler_v4 has 3 FAIL rows (2 share a check), 1 PASS and 1 MANUAL.
+        with PROWLER_V4_PATH.open('rb') as f:
+            findings = self.importer.parse_prowler_findings([f])
+        check_ids = {f['check_id'] for f in findings}
+        assert 'ec2_ebs_volume_encryption' not in check_ids  # PASS dropped
+        assert 'guardduty_is_enabled' not in check_ids        # MANUAL dropped
+        assert check_ids == {'s3_bucket_public_access', 'iam_password_policy_minimum_length_14'}
+
+    def test_merge_combines_resources_per_check(self):
+        with PROWLER_V4_PATH.open('rb') as f:
+            merged = self.importer.merge_findings_by_check(self.importer.parse_prowler_findings([f]))
+        by_check = {f['check_id']: f for f in merged}
+        assert len(merged) == 2
+        # The two FAIL rows for the same check collapse into one finding with both resources.
+        assert sorted(by_check['s3_bucket_public_access']['affected_components']) == [
+            'arn:aws:s3:::bucket-one', 'arn:aws:s3:::bucket-two',
+        ]
+
+    def test_severity_mapping(self):
+        with PROWLER_V4_PATH.open('rb') as f:
+            merged = self.importer.merge_findings_by_check(self.importer.parse_prowler_findings([f]))
+        by_check = {f['check_id']: f for f in merged}
+        assert by_check['s3_bucket_public_access']['severity'] == 'high'
+        assert by_check['iam_password_policy_minimum_length_14']['severity'] == 'medium'
+
+    def test_semicolon_delimiter_and_lowercase_aliases(self):
+        # prowler_v3 is ';'-delimited with lowercase headers - exercises both
+        # the delimiter sniffing and the column-alias resolution.
+        with PROWLER_V3_PATH.open('rb') as f:
+            merged = self.importer.merge_findings_by_check(self.importer.parse_prowler_findings([f]))
+        by_check = {f['check_id']: f for f in merged}
+        assert set(by_check) == {'rds_instance_backup_enabled', 'cloudtrail_multi_region_enabled'}
+        assert by_check['rds_instance_backup_enabled']['title'] == 'RDS instance has backups enabled'
+        assert by_check['rds_instance_backup_enabled']['service'] == 'rds'
+
+    def test_parse_notes_structure(self):
+        with PROWLER_V4_PATH.open('rb') as f:
+            notes = self.importer.parse_notes([f])
+        assert notes[0].title == 'Prowler'
+        assert notes[0].icon_emoji == '☁️'
+        # One child note per affected service.
+        service_titles = {n.title for n in notes[1:]}
+        assert {'s3', 'iam'} <= service_titles
+
+    def test_parse_findings_uses_fallback_template(self):
+        with PROWLER_V4_PATH.open('rb') as f:
+            findings = self.importer.parse_findings(files=[f], project=self.project)
+        assert len(findings) == 2
+        assert all(getattr(f, 'template_info', {}).get('is_fallback') for f in findings)
+
+
+@pytest.mark.django_db
+class TestProwlerOcsfImporter:
+    """Prowler v4/v5 also emit JSON-OCSF; the same importer detects and parses it."""
+
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.project = create_project(members=[create_user()])
+        self.importer = registry.get('prowler')
+
+    def test_is_format_detects_ocsf_json(self):
+        with PROWLER_OCSF_PATH.open('rb') as f:
+            assert self.importer.is_format(f) is True
+
+    def test_is_format_rejects_non_prowler_json(self):
+        # A JSON document without metadata.event_code is not Prowler OCSF output
+        # (e.g. a ScoutSuite report keyed by "services").
+        f = SimpleUploadedFile("other.json", b'{"services": {"s3": {}}}')
+        assert self.importer.is_format(f) is False
+
+    def test_only_failed_checks_are_kept(self):
+        # The fixture has 3 FAIL findings (2 share a check), 1 PASS and 1 MANUAL.
+        with PROWLER_OCSF_PATH.open('rb') as f:
+            findings = self.importer.parse_prowler_findings([f])
+        check_ids = {f['check_id'] for f in findings}
+        assert 'ec2_ebs_volume_encryption' not in check_ids  # PASS dropped
+        assert 'guardduty_is_enabled' not in check_ids        # MANUAL dropped
+        assert check_ids == {'s3_bucket_public_access', 'iam_password_policy_minimum_length_14'}
+
+    def test_merge_combines_resources_per_check(self):
+        with PROWLER_OCSF_PATH.open('rb') as f:
+            merged = self.importer.merge_findings_by_check(self.importer.parse_prowler_findings([f]))
+        by_check = {f['check_id']: f for f in merged}
+        assert len(merged) == 2
+        assert sorted(by_check['s3_bucket_public_access']['affected_components']) == [
+            'arn:aws:s3:::bucket-one', 'arn:aws:s3:::bucket-two',
+        ]
+
+    def test_field_and_severity_mapping(self):
+        with PROWLER_OCSF_PATH.open('rb') as f:
+            merged = self.importer.merge_findings_by_check(self.importer.parse_prowler_findings([f]))
+        s3 = next(f for f in merged if f['check_id'] == 's3_bucket_public_access')
+        assert s3['severity'] == 'high'
+        assert s3['title'] == 'S3 Bucket has public access configured'
+        assert s3['service'] == 's3'
+        assert s3['account'] == '123456789012'
+        # Remediation references from OCSF flow through (the CSV export has none).
+        assert any('block-public-access' in r for r in s3['references'])
+
+    def test_parse_findings_uses_fallback_template(self):
+        with PROWLER_OCSF_PATH.open('rb') as f:
+            findings = self.importer.parse_findings(files=[f], project=self.project)
+        assert len(findings) == 2
+        assert all(getattr(f, 'template_info', {}).get('is_fallback') for f in findings)

--- a/plugins/scanimport/tests/test_scoutsuite.py
+++ b/plugins/scanimport/tests/test_scoutsuite.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from sysreptor.tests.mock import create_project, create_user
+
+from ..importers import registry
+
+SCOUTSUITE_DATA_DIR = Path(__file__).parent / "data" / "scoutsuite"
+SCOUTSUITE_JS_PATH = SCOUTSUITE_DATA_DIR / "scoutsuite_results.js"
+SCOUTSUITE_JSON_PATH = SCOUTSUITE_DATA_DIR / "scoutsuite_results.json"
+
+
+@pytest.mark.django_db
+class TestScoutSuiteImporter:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.project = create_project(members=[create_user()])
+        self.importer = registry.get('scoutsuite')
+
+    def test_is_format_js_wrapper(self):
+        # The default ScoutSuite report is a .js file: `scoutsuite_results = {...};`
+        with SCOUTSUITE_JS_PATH.open('rb') as f:
+            assert self.importer.is_format(f) is True
+
+    def test_is_format_plain_json(self):
+        with SCOUTSUITE_JSON_PATH.open('rb') as f:
+            assert self.importer.is_format(f) is True
+
+    def test_is_format_rejects_json_without_services(self):
+        # A JSON document without a top-level "services" key is not ScoutSuite output
+        # (guards against grabbing e.g. SSLyze/ZAP JSON reports).
+        f = SimpleUploadedFile("other.json", b'{"server_scan_results": []}')
+        assert self.importer.is_format(f) is False
+
+    def test_is_format_rejects_non_json(self):
+        f = SimpleUploadedFile("data.txt", b"not json at all")
+        assert self.importer.is_format(f) is False
+
+    def test_level_maps_to_severity(self):
+        with SCOUTSUITE_JS_PATH.open('rb') as f:
+            findings = self.importer.parse_scoutsuite_findings([f])
+        by_id = {f['finding_id']: f for f in findings}
+        assert by_id['s3-bucket-allowing-cleartext']['severity'] == 'high'      # danger
+        assert by_id['s3-bucket-versioning-disabled']['severity'] == 'medium'   # warning
+        assert by_id['iam-password-policy-expiration']['severity'] == 'info'    # good_practice
+
+    def test_merge_combines_items_per_check(self):
+        with SCOUTSUITE_JS_PATH.open('rb') as f:
+            merged = self.importer.merge_findings_by_check(self.importer.parse_scoutsuite_findings([f]))
+        by_id = {f['finding_id']: f for f in merged}
+        assert by_id['s3-bucket-allowing-cleartext']['affected_components'] == [
+            'regions.eu-west-1.buckets.bucket-one',
+            'regions.eu-west-1.buckets.bucket-two',
+        ]
+
+    def test_metadata_extracted(self):
+        with SCOUTSUITE_JS_PATH.open('rb') as f:
+            findings = self.importer.parse_scoutsuite_findings([f])
+        by_id = {f['finding_id']: f for f in findings}
+        s3 = by_id['s3-bucket-allowing-cleartext']
+        assert s3['service'] == 's3'
+        assert s3['account'] == '123456789012'
+        assert s3['region'] == 'eu-west-1'
+        assert s3['references'] == ['https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html']
+
+    def test_parse_notes_structure(self):
+        with SCOUTSUITE_JS_PATH.open('rb') as f:
+            notes = self.importer.parse_notes([f])
+        assert notes[0].title == 'ScoutSuite'
+        assert notes[0].icon_emoji == '🔎'
+        service_titles = {n.title for n in notes[1:]}
+        assert {'s3', 'iam'} <= service_titles
+
+    def test_parse_findings_creates_one_per_check(self):
+        with SCOUTSUITE_JS_PATH.open('rb') as f:
+            findings = self.importer.parse_findings(files=[f], project=self.project)
+        assert len(findings) == 3


### PR DESCRIPTION
Adds native import support for AWS cloud scan output to the scanimport plugin, alongside the existing tools:

- Prowler: parses both the CSV report and the JSON-OCSF report (the two formats Prowler v4/v5 emit by default). CSV handles v3/v4 exports (';' or ',' delimited, column-name aliases handled); OCSF is read from the array of detection findings (check id from metadata.event_code, resources from resources[].uid, remediation references carried through). Only FAIL findings are imported; PASS/MANUAL are dropped. Findings are merged by CHECK_ID so one check across many resources becomes a single finding listing every affected resource.
- ScoutSuite: parses the default `scoutsuite_results_*.js` report (the `scoutsuite_results = {...};` wrapper is stripped) or a plain `.json` export. Findings are merged per (service, finding_id); ScoutSuite's danger/warning/good_practice levels map onto the info..critical scale.

Both importers follow the existing importer conventions: auto-detection via is_format(), notes and findings output, and customisation through `scanimport:prowler:<check_id>` / `scanimport:scoutsuite:<finding_id>` finding-template tags with a built-in fallback template.

Adds tests and sample fixtures (Prowler CSV v3/v4 and JSON-OCSF, ScoutSuite .js and .json) for both tools. Fixtures are picked up by the parametrised tests in test_importers.py (format detection, notes, findings) in addition to dedicated test_prowler.py / test_scoutsuite.py unit tests.