### PR TITLE
Minor typo fixes in Get Involved + Plugins pages

### DIFF
--- a/docs/docs/get-involved.md
+++ b/docs/docs/get-involved.md
@@ -55,7 +55,7 @@ answering questions in the community.
 ::: info <DocBadge icon="mdi:code-braces" label="Contribute to the core" />
 
 Fix bugs, implement new features, or improve existing functionality
-by contributing directly the SysReptor.
+by contributing directly to SysReptor.
 
 [Contributing guidelines](https://github.com/Syslifters/sysreptor/blob/main/CONTRIBUTING.md)
 

--- a/docs/docs/setup/plugins.md
+++ b/docs/docs/setup/plugins.md
@@ -90,7 +90,7 @@ and to change the `plugin_id` in `apps.py`.
 
 ### Plugin Loading
 Custom plugins need to be made available to the SysReptor docker container.
-This can be achived by extending the SysReptor docker image and adding your custom plugins to the image.
+This can be achieved by extending the SysReptor docker image and adding your custom plugins to the image.
 
 ```dockerfile title="Dockerfile example"
 ARG SYSREPTOR_VERSION="latest"


### PR DESCRIPTION
This PR fixes a small typo I noticed in the [Get Involved](https://docs.sysreptor.com/get-involved) page and the [Plugins](https://docs.sysreptor.com/setup/plugins) page that I noticed while reading the docs. 